### PR TITLE
Load requirements and run daily workflow

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -5,7 +5,7 @@ import feeds
 import datetime
 import requests
 from bs4 import BeautifulSoup
-from modules import journal, research, weather, spaceweather, emailer
+from modules import journal, weather, spaceweather, emailer
 from datamodel import Article
 def main():
     articles = []

--- a/modules/journal.py
+++ b/modules/journal.py
@@ -1,5 +1,5 @@
 import os
-import calendar_manually
+# import calendar_manually  # Commented out - macOS specific, not used
 import asyncio
 from claude import Claude as Generator
 class Journal(object):


### PR DESCRIPTION
- Remove unused 'research' module import from daily_workflow.py
- Comment out macOS-specific 'calendar_manually' import in journal.py (functionality already disabled)

These changes allow daily_workflow.py to run on Linux systems.